### PR TITLE
fix: logic value set to options.verbose

### DIFF
--- a/OEFPIL.m
+++ b/OEFPIL.m
@@ -205,7 +205,7 @@ if ~isfield(options, 'delta')
 end
 
 if ~isfield(options, 'verbose')
-    options.verbose = 'true';
+    options.verbose = true;
 end
 
 if ~isfield(options, 'isPlot')

--- a/OEFPIL2D.m
+++ b/OEFPIL2D.m
@@ -208,7 +208,7 @@ if ~isfield(options, 'delta')
 end
 
 if ~isfield(options, 'verbose')
-    options.verbose = 'true';
+    options.verbose = true;
 end
 
 if ~isfield(options, 'isPlot')


### PR DESCRIPTION
if undefined, structure options.verbose was set to string 'true'. instead the correct logic value true is set.

In a fact this caused no abnormal behaviour, however when I looked at the code to know what fields should be in the options strucure, I was mislead.

Up to it, the documentation on the options structure seems to be outdated.